### PR TITLE
Domain name updated to doppler.com

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -4,7 +4,7 @@ meta_desc: Provides an overview of the Doppler Provider for Pulumi.
 layout: overview
 ---
 
-The Doppler provider for Pulumi can be used to provision any of the monitoring resources available in [Doppler](https://dopplerhq.com/).
+The Doppler provider for Pulumi can be used to provision any of the monitoring resources available in [Doppler](https://doppler.com/).
 
 ## Example
 


### PR DESCRIPTION
Updated the link to the main website.

@rawkode is it still `app.dopplerhq.com`?

https://github.com/pulumiverse/pulumi-doppler/blob/eedcaec9010ff940aa643447ff8a92175bd0d720/docs/installation-configuration.md?plain=1#L34

I see the portal now being pointed to `dashboard.doppler.com`.

Signed-off-by: Ringo De Smet <ringo@de-smet.name>