### PR TITLE
Lock the version of the workflow files.

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,11 +8,11 @@ on:
 
 jobs:
   prerequisites:
-    uses: pulumiverse/infra/.github/workflows/provider-prerequisites.yaml@main
+    uses: pulumiverse/infra/.github/workflows/provider-prerequisites.yaml@actions-workflows-v0.0.1
     with:
       provider: doppler
   build:
     needs: prerequisites
-    uses: pulumiverse/infra/.github/workflows/provider-build-sdk.yaml@main
+    uses: pulumiverse/infra/.github/workflows/provider-build-sdk.yaml@actions-workflows-v0.0.1
     with:
       provider: doppler


### PR DESCRIPTION
Lock the version of the Github Actions workflow files. This allows to make breaking changes in these workflows without breaking all the users at the same time.

Signed-off-by: Ringo De Smet <ringo@de-smet.name>